### PR TITLE
[Add] .babelrc : add babel-plugin-styled-compoents

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+    "presets": ["next/babel"],
+    "plugins": [
+      [
+        "babel-plugin-styled-components", 
+        {
+          "ssr": true, // SSR을 위한 설정
+          "displayName": true, // 클래스명에 컴포넌트 이름을 붙임
+          "pure": true // dead code elimination (사용되지 않는 속성 제거)
+        }
+      ]
+    ]
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,12 @@
     "": {
       "name": "dcc_fe",
       "version": "0.1.0",
+      "license": "ISC",
       "dependencies": {
         "@types/node": "18.15.11",
         "@types/react": "18.0.31",
         "@types/react-dom": "18.0.11",
+        "babel-plugin-styled-components": "^2.0.7",
         "eslint": "8.37.0",
         "eslint-config-next": "13.2.4",
         "next": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "18.15.11",
     "@types/react": "18.0.31",
     "@types/react-dom": "18.0.11",
+    "babel-plugin-styled-components": "^2.0.7",
     "eslint": "8.37.0",
     "eslint-config-next": "13.2.4",
     "next": "13.2.4",


### PR DESCRIPTION
# Summary
- Next.js를 통한 SSR 프로젝트에서 Styled-Components 라이브러리를 사용하였을 때 클래스명이 일치하지 않는 오류를 해결하기 위한 라이브러리를 설치하였습니다.
- 설치 후 .babelrc 파일을 생성하여 babel 설정을 추가하였습니다.